### PR TITLE
Provide fat-jar url as a constant

### DIFF
--- a/src/main/scala/AssemblySettings.scala
+++ b/src/main/scala/AssemblySettings.scala
@@ -12,27 +12,53 @@ import AssemblyKeys._
 
 object AssemblySettings extends sbt.Plugin {
 
-  /* ### Setting keys 
+  /* ### Setting keys
 
      Classifier is the suffix appended to the artifact name
   */
   lazy val fatArtifactClassifier = settingKey[String]("Classifier of the fat jar artifact")
+  /* This setting holds the url of the published fat artifact */
+  lazy val fatArtifactUrl = settingKey[String]("URL of the published fat artifact")
 
-  /* ### Settings 
+  /* ### Settings
 
-     Note, that these settings are not included by default. To turn them on them, add to your 
+     Note, that these settings are not included by default. To turn them on them, add to your
      `build.sbt` `fatArtifactSettings` line (without any prefix)
   */
   lazy val fatArtifactSettings: Seq[Setting[_]] =
-    addArtifact(artifact in (Compile, assembly), assembly) ++ 
+    addArtifact(artifact in (Compile, assembly), assembly) ++
     Seq(
       // publishing fat artifact:
       fatArtifactClassifier := "fat",
       artifact in (Compile, assembly) := (artifact in (Compile, assembly)).value.copy(
         classifier = Some(fatArtifactClassifier.value)
       ),
+
       // turning off tests in assembly:
-      test in assembly := {}
+      test in assembly := {},
+
+      // mvn: "[organisation]/[module]_[scalaVersion]/[revision]/[artifact]-[revision]-[classifier].[ext]"
+      // ivy: "[organisation]/[module]_[scalaVersion]/[revision]/[type]s/[artifact]-[classifier].[ext]"
+      fatArtifactUrl := {
+        val isMvn = publishMavenStyle.value
+        val scalaV = "_"+scalaBinaryVersion.value
+        val module = moduleName.value + scalaV
+        val artifact = Seq(
+          if (isMvn) "" else "jars/",
+          module,
+          if (isMvn) "-"+version.value else "",
+          "-fat",
+          ".jar"
+        ).mkString
+
+        Seq(
+          ResolverSettings.publishS3Resolver.value.url,
+          organization.value,
+          module,
+          version.value,
+          artifact
+        ).mkString("/")
+      }
     )
 
 }


### PR DESCRIPTION
Putting this in every statika-distribution project is quite clumsy:

```scala
// mvn: "[organisation]/[module]_[scalaVersion]/[revision]/[artifact]-[revision]-[classifier].[ext]"
// ivy: "[organisation]/[module]_[scalaVersion]/[revision]/[type]s/[artifact]-[classifier].[ext]"
val fatUrl = Def.setting {
  val isMvn = publishMavenStyle.value
  val scalaV = "_"+scalaBinaryVersion.value
  val module = moduleName.value + scalaV
  val artifact =
    (if (isMvn) "" else "jars/") +
    module +
    (if (isMvn) "-"+version.value else "") +
    "-fat" +
    ".jar"

  Seq(
    publishS3Resolver.value.url,
    organization.value,
    module,
    version.value,
    artifact
  ).mkString("/")
}
```

As we know all this in advance, we could provide it as a constant which is imported together with the assembly-related settings. 
It could be also a setting, but I don't know how to change where sbt publishes all the artifacts.