### PR TITLE
Release-only tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,9 @@ addSbtPlugin("com.markatta"      % "taglist-plugin"     % "1.3.1")
 // https://github.com/puffnfresh/wartremover
 addSbtPlugin("org.brianmckenna"  % "sbt-wartremover"    % "0.14")
 
+libraryDependencies ++= Seq(
+  "org.scalatest" %% "scalatest" % "2.2.6"
+)
 
 wartremoverWarnings ++= Warts.allBut(Wart.NoNeedForMonad)
 


### PR DESCRIPTION
We frequently have the need for tests that create resources, perform expensive (time and money) operations etc. It would good to be able to mark those tests as "release-only", making sure that they will be run when (and only when) you are making a release.

I'm guessing this could be done using scalatest tags

- [Scalatest docs -- tagging your tests](http://www.scalatest.org/user_guide/tagging_your_tests)

and redefining `sbt test` so that normally it would exclude "release-only" tests. Found this about it:

- [Hootsuite blog -- How to Run Tagged Scala Tests with SBT and ScalaTest](http://code.hootsuite.com/tagged-tests-with-sbt/)