### PR TITLE
Split fatArtifactSettings and fat-jar publishing

### DIFF
--- a/src/main/scala/AssemblySettings.scala
+++ b/src/main/scala/AssemblySettings.scala
@@ -20,22 +20,12 @@ object AssemblySettings extends sbt.Plugin {
   /* This setting holds the url of the published fat artifact */
   lazy val fatArtifactUrl = settingKey[String]("URL of the published fat artifact")
 
-  lazy val fatArtifactPublish = settingKey[Boolean]("Defines whether to publish fat jar or not")
-
   /* ### Settings
 
-     Note, that these settings are not included by default. To turn them on them, add to your
-     `build.sbt` `fatArtifactSettings` line (without any prefix)
   */
   lazy val fatArtifactSettings: Seq[Setting[_]] = Seq(
-    // publishing fat artifact:
+    // suffix for the fat artifact:
     fatArtifactClassifier := "fat",
-    fatArtifactPublish := !(isSnapshot.value), // don't publish fat snapshots
-    artifact in (Compile, assembly) := {
-      val art = (artifact in (Compile, assembly)).value
-      art.copy( classifier = Some(fatArtifactClassifier.value) )
-    },
-
     // turning off tests in assembly:
     test in assembly := {},
 
@@ -61,11 +51,15 @@ object AssemblySettings extends sbt.Plugin {
         artifact
       ).mkString("/")
     }
-
   )
-  // ++ Def.settings(
-  //   if (fatArtifactPublish.value) addArtifact(artifact in (Compile, assembly), assembly)
-  //   else seq()
-  // )
+
+  /* Note, that these settings are not included by default. To turn them on them, add to your
+     `build.sbt` `fatArtifactPublishing` line (without any prefix) */
+  lazy val fatArtifactPublishing: Seq[Setting[_]] = Seq(
+    artifact in (Compile, assembly) := {
+      val art = (artifact in (Compile, assembly)).value
+      art.copy( classifier = Some(fatArtifactClassifier.value) )
+    }
+  ) ++ addArtifact(artifact in (Compile, assembly), assembly)
 
 }

--- a/src/main/scala/AssemblySettings.scala
+++ b/src/main/scala/AssemblySettings.scala
@@ -20,45 +20,52 @@ object AssemblySettings extends sbt.Plugin {
   /* This setting holds the url of the published fat artifact */
   lazy val fatArtifactUrl = settingKey[String]("URL of the published fat artifact")
 
+  lazy val fatArtifactPublish = settingKey[Boolean]("Defines whether to publish fat jar or not")
+
   /* ### Settings
 
      Note, that these settings are not included by default. To turn them on them, add to your
      `build.sbt` `fatArtifactSettings` line (without any prefix)
   */
-  lazy val fatArtifactSettings: Seq[Setting[_]] =
-    addArtifact(artifact in (Compile, assembly), assembly) ++
-    Seq(
-      // publishing fat artifact:
-      fatArtifactClassifier := "fat",
-      artifact in (Compile, assembly) := (artifact in (Compile, assembly)).value.copy(
-        classifier = Some(fatArtifactClassifier.value)
-      ),
+  lazy val fatArtifactSettings: Seq[Setting[_]] = Seq(
+    // publishing fat artifact:
+    fatArtifactClassifier := "fat",
+    fatArtifactPublish := !(isSnapshot.value), // don't publish fat snapshots
+    artifact in (Compile, assembly) := {
+      val art = (artifact in (Compile, assembly)).value
+      art.copy( classifier = Some(fatArtifactClassifier.value) )
+    },
 
-      // turning off tests in assembly:
-      test in assembly := {},
+    // turning off tests in assembly:
+    test in assembly := {},
 
-      // mvn: "[organisation]/[module]_[scalaVersion]/[revision]/[artifact]-[revision]-[classifier].[ext]"
-      // ivy: "[organisation]/[module]_[scalaVersion]/[revision]/[type]s/[artifact]-[classifier].[ext]"
-      fatArtifactUrl := {
-        val isMvn = publishMavenStyle.value
-        val scalaV = "_"+scalaBinaryVersion.value
-        val module = moduleName.value + scalaV
-        val artifact = Seq(
-          if (isMvn) "" else "jars/",
-          module,
-          if (isMvn) "-"+version.value else "",
-          "-fat",
-          ".jar"
-        ).mkString
+    // mvn: "[organisation]/[module]_[scalaVersion]/[revision]/[artifact]-[revision]-[classifier].[ext]"
+    // ivy: "[organisation]/[module]_[scalaVersion]/[revision]/[type]s/[artifact]-[classifier].[ext]"
+    fatArtifactUrl := {
+      val isMvn = publishMavenStyle.value
+      val scalaV = "_"+scalaBinaryVersion.value
+      val module = moduleName.value + scalaV
+      val artifact = Seq(
+        if (isMvn) "" else "jars/",
+        module,
+        if (isMvn) s"-${version.value}" else "",
+        s"-${fatArtifactClassifier.value}",
+        ".jar"
+      ).mkString
 
-        Seq(
-          ResolverSettings.publishS3Resolver.value.url,
-          organization.value,
-          module,
-          version.value,
-          artifact
-        ).mkString("/")
-      }
-    )
+      Seq(
+        ResolverSettings.publishS3Resolver.value.url,
+        organization.value,
+        module,
+        version.value,
+        artifact
+      ).mkString("/")
+    }
+
+  )
+  // ++ Def.settings(
+  //   if (fatArtifactPublish.value) addArtifact(artifact in (Compile, assembly), assembly)
+  //   else seq()
+  // )
 
 }

--- a/src/main/scala/AssemblySettings.scala
+++ b/src/main/scala/AssemblySettings.scala
@@ -55,11 +55,11 @@ object AssemblySettings extends sbt.Plugin {
 
   /* Note, that these settings are not included by default. To turn them on them, add to your
      `build.sbt` `fatArtifactPublishing` line (without any prefix) */
-  lazy val fatArtifactPublishing: Seq[Setting[_]] = Seq(
-    artifact in (Compile, assembly) := {
-      val art = (artifact in (Compile, assembly)).value
+  def fatArtifactPublishing(conf: Configuration): Seq[Setting[_]] = Seq(
+    artifact in (conf, assembly) := {
+      val art = (artifact in (conf, assembly)).value
       art.copy( classifier = Some(fatArtifactClassifier.value) )
     }
-  ) ++ addArtifact(artifact in (Compile, assembly), assembly)
+  ) ++ addArtifact(artifact in (conf, assembly), assembly)
 
 }

--- a/src/main/scala/NiceProjectConfigs.scala
+++ b/src/main/scala/NiceProjectConfigs.scala
@@ -1,6 +1,6 @@
 /* ## Project configurations
-   
-   This is the module defining project configurations, which are 
+
+   This is the module defining project configurations, which are
    just combinations of the setting sets defined in other modules.
 */
 package ohnosequences.sbt.nice
@@ -10,7 +10,7 @@ import Keys._
 import sbt.Extracted
 
 object NiceProjectConfigs extends sbt.Plugin {
-  
+
   object Nice {
 
     /* You can just say somewhere **in the very beginning** of your `build.sbt`:
@@ -28,7 +28,8 @@ object NiceProjectConfigs extends sbt.Plugin {
       DocumentationSettings.documentationSettings ++
       ReleaseSettings.releaseSettings ++
       TagListSettings.tagListSettings ++
-      WartremoverSettings.wartremoverSettings
+      WartremoverSettings.wartremoverSettings ++
+      AssemblySettings.fatArtifactSettings
 
     /* Same for `Nice.javaProject` - it includes all `scalaProject` settings,
        Note that default java version is 1.7. You can change it after loading these settings:


### PR DESCRIPTION
Sometimes it's useful to to have the settings for fat artifact, but turn off publishing, or to switch fat-jar publishing to another config (say `Test`)