### PR TITLE
Generating metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,28 +6,19 @@ sbtPlugin := true
 scalaVersion := "2.10.6"
 bucketSuffix := "era7.com"
 
-// https://github.com/ohnosequences/sbt-s3-resolver
-addSbtPlugin("ohnosequences"     % "sbt-s3-resolver"    % "0.14.0")
-// https://github.com/ohnosequences/sbt-github-release
-addSbtPlugin("ohnosequences"     % "sbt-github-release" % "0.3.0")
-// https://github.com/sbt/sbt-release
-addSbtPlugin("com.github.gseitz" % "sbt-release"        % "1.0.3")
-// https://github.com/sbt/sbt-assembly
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"       % "0.14.3")
-// https://github.com/rtimush/sbt-updates
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.1.10")
-// https://github.com/laughedelic/literator
-addSbtPlugin("laughedelic"       % "literator"          % "0.7.0")
-// https://github.com/johanandren/sbt-taglist
-addSbtPlugin("com.markatta"      % "taglist-plugin"     % "1.3.1")
-// https://github.com/puffnfresh/wartremover
-addSbtPlugin("org.wartremover"  % "sbt-wartremover"    % "1.0.1")
-
+addSbtPlugin("ohnosequences"     % "sbt-s3-resolver" % "0.14.0")  // https://github.com/ohnosequences/sbt-s3-resolver
+addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.3")   // https://github.com/sbt/sbt-release
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "0.14.3")  // https://github.com/sbt/sbt-assembly
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"     % "0.1.10")  // https://github.com/rtimush/sbt-updates
+addSbtPlugin("laughedelic"       % "literator"       % "0.7.0")   // https://github.com/laughedelic/literator
+addSbtPlugin("com.markatta"      % "taglist-plugin"  % "1.3.1")   // https://github.com/johanandren/sbt-taglist
+addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "1.0.1")   // https://github.com/puffnfresh/wartremover
+addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"   % "0.6.1")   // https://github.com/sbt/sbt-buildinfo
 
 wartremoverWarnings ++= Warts.allBut(Wart.NoNeedForMonad)
 
 dependencyOverrides ++= Set(
-  "commons-codec" % "commons-codec" % "1.10",
+  "commons-codec"              % "commons-codec"    % "1.10",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4",
-  "joda-time" % "joda-time" % "2.8"
+  "joda-time"                  % "joda-time"        % "2.8"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,15 @@ sbtPlugin := true
 scalaVersion := "2.10.6"
 bucketSuffix := "era7.com"
 
-addSbtPlugin("ohnosequences"     % "sbt-s3-resolver" % "0.14.0")  // https://github.com/ohnosequences/sbt-s3-resolver
-addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.3")   // https://github.com/sbt/sbt-release
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "0.14.3")  // https://github.com/sbt/sbt-assembly
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"     % "0.1.10")  // https://github.com/rtimush/sbt-updates
-addSbtPlugin("laughedelic"       % "literator"       % "0.7.0")   // https://github.com/laughedelic/literator
-addSbtPlugin("com.markatta"      % "taglist-plugin"  % "1.3.1")   // https://github.com/johanandren/sbt-taglist
-addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "1.0.1")   // https://github.com/puffnfresh/wartremover
-addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"   % "0.6.1")   // https://github.com/sbt/sbt-buildinfo
+addSbtPlugin("ohnosequences"     % "sbt-s3-resolver"    % "0.14.0")  // https://github.com/ohnosequences/sbt-s3-resolver
+addSbtPlugin("ohnosequences"     % "sbt-github-release" % "0.3.0")   // https://github.com/ohnosequences/sbt-github-release
+addSbtPlugin("com.github.gseitz" % "sbt-release"        % "1.0.3")   // https://github.com/sbt/sbt-release
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"       % "0.14.3")  // https://github.com/sbt/sbt-assembly
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.1.10")  // https://github.com/rtimush/sbt-updates
+addSbtPlugin("laughedelic"       % "literator"          % "0.7.0")   // https://github.com/laughedelic/literator
+addSbtPlugin("com.markatta"      % "taglist-plugin"     % "1.3.1")   // https://github.com/johanandren/sbt-taglist
+addSbtPlugin("org.wartremover"   % "sbt-wartremover"    % "1.0.1")   // https://github.com/puffnfresh/wartremover
+addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"      % "0.6.1")   // https://github.com/sbt/sbt-buildinfo
 
 wartremoverWarnings ++= Warts.allBut(Wart.NoNeedForMonad)
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ addSbtPlugin("com.markatta"      % "taglist-plugin"     % "1.3.1")   // https://
 addSbtPlugin("org.wartremover"   % "sbt-wartremover"    % "1.0.1")   // https://github.com/puffnfresh/wartremover
 addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo"      % "0.6.1")   // https://github.com/sbt/sbt-buildinfo
 
-wartremoverWarnings ++= Warts.allBut(Wart.NoNeedForMonad)
+wartremoverErrors in (Compile, compile) := Seq()
+// wartremoverWarnings ++= Warts.allBut(Wart.NoNeedForMonad)
 
 dependencyOverrides ++= Set(
   "commons-codec"              % "commons-codec"    % "1.10",

--- a/notes/next.markdown
+++ b/notes/next.markdown
@@ -1,6 +1,7 @@
 * Major changes:
-  - #47: Translated all settings-modules to [auto-plugins](http://www.scala-sbt.org/0.13/docs/Plugins.html) with proper dependencies between them. They will be [enabled](http://www.scala-sbt.org/0.13/docs/Using-Plugins.html#Enabling+and+disabling+auto+plugins) automatically, so you can disable some of them explicitly if needed.  
-    The only plugin that doesn't enable itself automatically the one for Java-only projects. To switch it on you have to add `enablePlugin(JavaOnlySettings)` to your `build.sbt`.
+  - #47: Translated all settings-modules to [auto-plugins](http://www.scala-sbt.org/0.13/docs/Plugins.html) with proper dependencies between them. They will be [enabled](http://www.scala-sbt.org/0.13/docs/Using-Plugins.html#Enabling+and+disabling+auto+plugins) automatically, so you can disable some of them explicitly if needed. Plugins that need to be ebaled explicitly:
+    + The one for Java-only projects: add `enablePlugins(JavaOnlySettings)` to enable it
+    + #39: New `StatikaBundleSettings` plugin, which adds dependency on Statika (version is configurable with `statikaVersion`) and uses [sbt-buildinfo](https://github.com/sbt/sbt-buildinfo) to generate the artifact metadata for statika bundles. Add `enablePlugins(StatikaBundleSettings)` to enable it.
   - #45: The new `AssemblySettings` auto-plugin loads fat-jar related settings automatically, but to publish the generated artifact, you need to add `addFatArtifactPublishing(<config>)` setting to your `build.sbt` explicitly (default `<config>` is `Compile`).
 
 

--- a/src/main/scala/JavaOnlySettings.scala
+++ b/src/main/scala/JavaOnlySettings.scala
@@ -9,9 +9,9 @@ import Keys._
 
 case object JavaOnlySettings extends sbt.AutoPlugin {
 
-  override def requires = plugins.JvmPlugin
   // NOTE: it means that the plugin has to be manually activated: `enablePlugin(JavaOnlySettings)`
-  override def trigger = noTrigger
+  override def trigger  = noTrigger
+  override def requires = plugins.JvmPlugin
 
   case object autoImport {
 

--- a/src/main/scala/StatikaBundleSettings.scala
+++ b/src/main/scala/StatikaBundleSettings.scala
@@ -1,0 +1,40 @@
+/* ## Statika artifact metadata settings
+
+   This plugin adds a dependency on Statika and generates artifact metadata for bundles.
+*/
+package ohnosequences.sbt.nice
+
+import sbt._, Keys._
+import sbtbuildinfo._, BuildInfoKeys._
+
+object StatikaBundleSettings extends sbt.AutoPlugin {
+
+  // NOTE: it means that the plugin has to be manually activated: `enablePlugin(JavaOnlySettings)`
+  override def trigger  = noTrigger
+  override def requires =
+    sbtbuildinfo.BuildInfoPlugin &&
+    AssemblySettings
+
+  case object autoImport {
+
+    lazy val statikaVersion = settingKey[String]("Statika library version")
+  }
+  import autoImport._
+
+  /* ### Settings */
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    statikaVersion := "2.0.0-M5",
+    libraryDependencies += "ohnosequences" %% "statika" % statikaVersion.value,
+
+    buildInfoPackage := "generated.metadata",
+    buildInfoObject  := normalizedName.value,
+    buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata")),
+    buildInfoKeys    := Seq[BuildInfoKey](
+      organization,
+      version,
+      "artifact" -> normalizedName.value,
+      "artifactUrl" -> AssemblySettings.autoImport.fatArtifactUrl.value
+    )
+  )
+
+}


### PR DESCRIPTION
This comes from the same problem as #38. Here is the code that is currently pasted in every build.sbt (besides the mentioned fat-jar url):

```scala
val metadataObject = Def.setting { name.value.split("""\W""").map(_.capitalize).mkString }

val generateMetadata = Def.task {

  val text = s"""
    |package generated.metadata
    |
    |import ohnosequences.statika.bundles._
    |
    |case object ${metadataObject.value} extends AnyArtifactMetadata {
    |  val organization: String = "${organization.value}"
    |  val artifact:     String = "${name.value.toLowerCase}"
    |  val version:      String = "${version.value}"
    |  val artifactUrl:  String = "${fatUrl.value}"
    |}
    |""".stripMargin

  val file = (sourceManaged in Compile).value / "statika" / "metadata.scala"
  IO.write(file, text)
  Seq(file)
}

sourceGenerators in Compile += generateMetadata.taskValue
```