### PR TITLE
name for release-only test tag wrong

### DIFF
--- a/src/main/scala/Release.scala
+++ b/src/main/scala/Release.scala
@@ -212,9 +212,9 @@ case object Release {
   def generateTestTags: DefTask[Seq[File]] = Def.task {
     val file = (sourceManaged in Test).value / "tags.scala"
 
-    val parts = Keys.releaseOnlyTestTag.value.split('.')
-    val pkg = parts.init.mkString(".")
-    val obj = parts.last
+    lazy val parts = Keys.releaseOnlyTestTag.value.split('.')
+    lazy val pkg = parts.init.mkString(".")
+    lazy val obj = parts.last
 
     IO.write(file, s"""
       |package ${pkg}


### PR DESCRIPTION
You get this:

``` scala
package sbt.SettingKey$$anon$4@735db6aa

case object ReleaseOnlyTest
  extends org.scalatest.Tag(sbt.SettingKey$$anon$4@735db6aa.ReleaseOnlyTest)
```

In the sbt console `releaseOnlyTestTagPackage` is OK, but it looks like the source generator does not work.

