### PR TITLE
Release 0.10.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,12 +11,12 @@ bucketSuffix := "era7.com"
 
 resolvers += "Github-API" at "http://repo.jenkins-ci.org/public/"
 
+addSbtPlugin("org.wartremover"   % "sbt-wartremover"    % "2.2.1")   // https://github.com/puffnfresh/wartremover
 addSbtPlugin("ohnosequences"     % "sbt-s3-resolver"    % "0.19.0")  // https://github.com/ohnosequences/sbt-s3-resolver
 addSbtPlugin("ohnosequences"     % "sbt-github-release" % "0.7.1")   // https://github.com/ohnosequences/sbt-github-release
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"       % "0.14.6")  // https://github.com/sbt/sbt-assembly
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"       % "0.14.9")  // https://github.com/sbt/sbt-assembly
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.3.4")   // https://github.com/rtimush/sbt-updates
 addSbtPlugin("com.markatta"      % "sbt-taglist"        % "1.4.0")   // https://github.com/johanandren/sbt-taglist
-addSbtPlugin("org.wartremover"   % "sbt-wartremover"    % "2.2.1")   // https://github.com/puffnfresh/wartremover
 
 dependencyOverrides ++= Seq(
   "commons-codec"              % "commons-codec"    % "1.9",

--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,15 @@ name := "nice-sbt-settings"
 organization := "ohnosequences"
 description := "sbt plugin accumulating some useful and nice sbt settings"
 
-scalaVersion := "2.12.4"
-sbtVersion in Global := "1.0.4"
+scalaVersion := "2.12.7"
+sbtVersion in Global := "1.2.6"
 
 bucketSuffix := "era7.com"
 
-resolvers += Resolver.jcenterRepo
 resolvers += "Github-API" at "http://repo.jenkins-ci.org/public/"
 
 addSbtPlugin("ohnosequences"     % "sbt-s3-resolver"    % "0.19.0")  // https://github.com/ohnosequences/sbt-s3-resolver
-addSbtPlugin("ohnosequences"     % "sbt-github-release" % "0.7.0")   // https://github.com/ohnosequences/sbt-github-release
+addSbtPlugin("ohnosequences"     % "sbt-github-release" % "0.7.1")   // https://github.com/ohnosequences/sbt-github-release
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"       % "0.14.6")  // https://github.com/sbt/sbt-assembly
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.3.4")   // https://github.com/rtimush/sbt-updates
 addSbtPlugin("com.markatta"      % "sbt-taglist"        % "1.4.0")   // https://github.com/johanandren/sbt-taglist

--- a/notes/0.10.1.markdown
+++ b/notes/0.10.1.markdown
@@ -1,0 +1,1 @@
+* #66: Updates dependencies and includes a hotfix in [sbt-github-release v0.7.1](https://github.com/ohnosequences/sbt-github-release/releases/tag/v0.7.1).


### PR DESCRIPTION
Bumps `sbt-github-release` to `v0.7.1`, which solves a bug when name of package in `*.sbt` configuration file does not match the name of the repo in github.